### PR TITLE
Handle single localization set

### DIFF
--- a/src/DependencyInjection/PrintdealPandosearchExtension.php
+++ b/src/DependencyInjection/PrintdealPandosearchExtension.php
@@ -17,6 +17,7 @@ class PrintdealPandosearchExtension extends ConfigurableExtension implements Pre
     const LOCALIZED_URL_TEMPLATE = self::BASE_URL_TEMPLATE . '%s/';
 
     const GUZZLE_CLIENT_NAME = 'printdeal.pandosearch_client.%s';
+    const DEFAULT_GUZZLE_CLIENT_SUFFIX = 'default';
 
     /**
      * @inheritDoc
@@ -55,14 +56,14 @@ class PrintdealPandosearchExtension extends ConfigurableExtension implements Pre
     private function getClientsConfiguration(ContainerBuilder $container)
     {
         $config = $this->getConfig($container);
-        $localizations = $config['localizations'] ?? [];
+        $localizations = $this->getLocalizations($config);
         $companyName = (string)$config['company_name'];
         $searchProtocol = (string)$config['search']['protocol'];
         $searchHost = (string)$config['search']['host'];
         $guzzleConfig = $config['guzzle_client'];
         if (!$localizations) {
             return [
-                sprintf(self::GUZZLE_CLIENT_NAME, 'default') => [
+                sprintf(self::GUZZLE_CLIENT_NAME, self::DEFAULT_GUZZLE_CLIENT_SUFFIX) => [
                     'config' => $this->getClientConfiguration(
                         $searchProtocol,
                         $searchHost,
@@ -151,5 +152,14 @@ class PrintdealPandosearchExtension extends ConfigurableExtension implements Pre
             $companyName,
             $localization
         ) : sprintf(self::BASE_URL_TEMPLATE, $searchProtocol, $searchHost, $companyName);
+    }
+
+    /**
+     * @param array $config
+     * @return array
+     */
+    private function getLocalizations(array $config): array
+    {
+        return isset($config['localizations']) && count($config['localizations']) > 1 ? $config['localizations'] : [];
     }
 }

--- a/src/Locator/HttpClientLocator.php
+++ b/src/Locator/HttpClientLocator.php
@@ -3,10 +3,13 @@
 namespace Printdeal\PandosearchBundle\Locator;
 
 use GuzzleHttp\ClientInterface;
+use Printdeal\PandosearchBundle\DependencyInjection\PrintdealPandosearchExtension;
 use Printdeal\PandosearchBundle\Exception\ClientNotFoundException;
 
 class HttpClientLocator
 {
+    const DEFAULT_GUZZLE_CLIENT = PrintdealPandosearchExtension::DEFAULT_GUZZLE_CLIENT_SUFFIX;
+
     private $clients = [];
 
     /**
@@ -20,13 +23,17 @@ class HttpClientLocator
 
     /**
      * @param string $localization
-     * @return mixed
+     * @return ClientInterface
      * @throws ClientNotFoundException
      */
-    public function getClient(string $localization = 'default'): ClientInterface
+    public function getClient(string $localization = self::DEFAULT_GUZZLE_CLIENT): ClientInterface
     {
         if (isset($this->clients[$localization])) {
             return $this->clients[$localization];
+        }
+
+        if (count($this->clients) === 1) {
+            return reset($this->clients);
         }
 
         throw new ClientNotFoundException($localization);

--- a/tests/Locator/HttpClientLocatorTest.php
+++ b/tests/Locator/HttpClientLocatorTest.php
@@ -65,4 +65,18 @@ class HttpClientLocatorTest extends TestCase
 
         $this->assertEquals($clientMock, $clientLocator->getClient($localization));
     }
+
+    public function testClientForSingleLanguageFound()
+    {
+        $localization = 'default';
+
+        $clientMock = $this->getMockBuilder(ClientInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $clientLocator = $this->getClientLocator();
+        $clientLocator->addHttpClient($localization, $clientMock);
+
+        $this->assertEquals($clientMock, $clientLocator->getClient('nl'));
+    }
 }


### PR DESCRIPTION
Create default guzzle client without localization preset if only one translation was set.
Return default guzzle client if search or suggestion was called at one-translation project.