### PR TITLE
Replace parameter at localizations with parameter value

### DIFF
--- a/src/DependencyInjection/Compiler/HttpClientsPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientsPass.php
@@ -4,7 +4,6 @@ namespace Printdeal\PandosearchBundle\DependencyInjection\Compiler;
 
 use Csa\Bundle\GuzzleBundle\DependencyInjection\CompilerPass\MiddlewarePass;
 use Printdeal\PandosearchBundle\DependencyInjection\PrintdealPandosearchExtension;
-use Printdeal\PandosearchBundle\Locator\HttpClientLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;

--- a/src/DependencyInjection/PrintdealPandosearchExtension.php
+++ b/src/DependencyInjection/PrintdealPandosearchExtension.php
@@ -173,10 +173,11 @@ class PrintdealPandosearchExtension extends ConfigurableExtension implements Pre
         $localizationParameter = [];
         if (is_string($localizations) &&
             $container instanceof ContainerBuilder &&
-            preg_match('/^%(.*)%$/', $localizations, $localizationParameter)) {
+            preg_match('/^%(.*)%$/', $localizations, $localizationParameter) &&
+            $container->hasParameter($localizationParameter[1])) {
             $localizations = $container->getParameter($localizationParameter[1]);
         }
 
-        return count($localizations) > 1 ? $localizations : [];
+        return is_array($localizations) && count($localizations) > 1 ? $localizations : [];
     }
 }

--- a/src/DependencyInjection/PrintdealPandosearchExtension.php
+++ b/src/DependencyInjection/PrintdealPandosearchExtension.php
@@ -172,6 +172,7 @@ class PrintdealPandosearchExtension extends ConfigurableExtension implements Pre
 
         $localizationParameter = [];
         if (is_string($localizations) &&
+            $container instanceof ContainerBuilder &&
             preg_match('/^%(.*)%$/', $localizations, $localizationParameter)) {
             $localizations = $container->getParameter($localizationParameter[1]);
         }

--- a/src/DependencyInjection/PrintdealPandosearchExtension.php
+++ b/src/DependencyInjection/PrintdealPandosearchExtension.php
@@ -60,7 +60,7 @@ class PrintdealPandosearchExtension extends ConfigurableExtension implements Pre
     private function getClientsConfiguration(ContainerBuilder $container)
     {
         $config = $this->getConfig($container);
-        $localizations = $this->getLocalizations($config);
+        $localizations = $this->getLocalizations($config, $container);
         $companyName = (string)$config['company_name'];
         $searchProtocol = (string)$config['search']['protocol'];
         $searchHost = (string)$config['search']['host'];
@@ -160,10 +160,22 @@ class PrintdealPandosearchExtension extends ConfigurableExtension implements Pre
 
     /**
      * @param array $config
+     * @param ContainerBuilder|null $container
      * @return array
      */
-    private function getLocalizations(array $config): array
+    private function getLocalizations(array $config, ContainerBuilder $container = null): array
     {
-        return isset($config['localizations']) && count($config['localizations']) > 1 ? $config['localizations'] : [];
+        if (!isset($config['localizations'])) {
+            return [];
+        }
+        $localizations = $config['localizations'];
+
+        $localizationParameter = [];
+        if (is_string($localizations) &&
+            preg_match('/^%(.*)%$/', $localizations, $localizationParameter)) {
+            $localizations = $container->getParameter($localizationParameter[1]);
+        }
+
+        return count($localizations) > 1 ? $localizations : [];
     }
 }

--- a/tests/DependencyInjection/PrintdealPandosearchExtensionTest.php
+++ b/tests/DependencyInjection/PrintdealPandosearchExtensionTest.php
@@ -16,7 +16,7 @@ class PrintdealPandosearchExtensionTest extends TestCase
      * @param array $expectedServices
      * @dataProvider localizationsProvider
      */
-    public function testLoadConfigurationWithMultipleLanguages(array $localization, array $expectedServices)
+    public function testWithLanguages(array $localization, array $expectedServices)
     {
         $container = $this->createContainer();
         $container->registerExtension(new CsaGuzzleExtension());
@@ -46,6 +46,31 @@ class PrintdealPandosearchExtensionTest extends TestCase
                 [sprintf(HttpClientsPass::GUZZLE_CLIENTS_SERVICES_NAME, 'default')]
             ]
         ];
+    }
+
+    /**
+     * @param array $localizations
+     * @param array $expectedServices
+     * @dataProvider localizationsProvider
+     */
+    public function testWithLanguagesFromParameter(
+        array $localizations,
+        array $expectedServices
+    ) {
+        $parameterName = 'parameter.printdeal.localization';
+
+        $container = $this->createContainer();
+        $container->registerExtension(new CsaGuzzleExtension());
+        $container->registerExtension(new PrintdealPandosearchExtension());
+        $container->setParameter($parameterName, $localizations);
+        $container->loadFromExtension('printdeal_pandosearch', [
+            'localizations' => '%' . $parameterName . '%',
+        ]);
+        $this->compileContainer($container);
+
+        foreach ($expectedServices as $expectedService) {
+            static::assertTrue($container->hasDefinition($expectedService));
+        }
     }
 
     /**


### PR DESCRIPTION
Before generating new CSA clients - check is localizations is a parameter and replace it with actual value if needed.
Resolving ISSUE #19 