### PR TITLE
activate test at php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 7
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 install:
   - composer self-update


### PR DESCRIPTION
previously nightly was 7.3, now it is 7.4, so we should activate test at 7.3 manually