### PR TITLE
Remove PHP nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4-dev
 install:
   - composer self-update
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - nightly
+  - 7.4
 install:
   - composer self-update
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4
+  - 7.4-dev
 install:
   - composer self-update
 before_script:


### PR DESCRIPTION
PHP 8 is not supported yet by most dependencies, so nightly version was removed from build options.